### PR TITLE
enlarged `maxBuffer`

### DIFF
--- a/bin/installCompiler.js
+++ b/bin/installCompiler.js
@@ -34,7 +34,7 @@ var build = function (done) {
     ];
 
     console.log('Building...');
-    exec(cmd.join(' && '), function (error, stdout, stderr) {
+    exec(cmd.join(' && '), {maxBuffer: 2000 * 1024}, function (error, stdout, stderr) {
         if (error) throw new Error(error);
 
         console.log('Linked to Capnproto compiler.');


### PR DESCRIPTION
default `maxBuffer` failed to build under nodejs v10.4.1